### PR TITLE
Exclude pytorch 1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "matplotlib >= 2.0.0",
     "pysam >= 0.15.0",
     "scipy >= 1",
-    "torch >= 1",
+    "torch >= 1, < 1.1",
 ]
 
 


### PR DESCRIPTION
Exclude pytorch 1.1 because of incompatibility with models