### PR TITLE
Fix setup script to use list for package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ for Oxford Nanopore Technologies' sequencing platforms.""",
     ],
 
     packages=find_packages(exclude=["*.test", "*.test.*", "test.*", "test", "bin"]),
-    package_data={'configs': 'data/configs/*'},
+    package_data={'configs': ['data/configs/*']},
     exclude_package_data={'': ['*.hdf', '*.c', '*.h']},
     ext_modules=extensions,
     setup_requires=["pytest-runner", "pytest-xdist"],


### PR DESCRIPTION
A change to setuptools means that package_data now requires that its values are lists rather than strings (<https://github.com/pypa/setuptools/pull/1769>) which means that the setup.py file is currently broken with the latest version.