### PR TITLE
change python version in shebang

### DIFF
--- a/bin/prepare_mapped_reads.py
+++ b/bin/prepare_mapped_reads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 
 import numpy as np


### PR DESCRIPTION
`prepare_mapped_reads.py` seems to be the only script within `bin/` missing the correct python version (v3) in its shebang.  

Therefore, when executing it, depending on the system, you will get python2 rather than the expected python3.