### PR TITLE
Fix upper limit on Biopython (support py3.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 h5py >= 2.2.1,<=2.6.0
 numpy >= 1.14.5
-biopython >= 1.63
+#  Biopython 1.76 last version to support Python 3.5
+biopython >= 1.63, <=1.76
 Cython >= 0.25.2
 wheel >= 0.29.0
 ont_fast5_api == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ version = taiyaki.__version__
 install_requires = [
     "h5py >= 2.2.1",
     "numpy >= 1.14.5",
-    "biopython >= 1.63",
+    #  Biopython 1.76 last version to support Python 3.5
+    "biopython >= 1.63, <=1.76",
     "Cython >= 0.25.2",
     "ont_fast5_api >= 1.2.0",
     "matplotlib >= 2.0.0",


### PR DESCRIPTION
(cherry picked from commit f19d6549150df7a611bfd1179a0dc9e110d175ab)