### PR TITLE
Revert "Fix upper limit on Biopython (support py3.5)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 h5py >= 2.2.1,<=2.6.0
 numpy >= 1.14.5
-#  Biopython 1.76 last version to support Python 3.5
-biopython >= 1.63, <=1.76
+biopython >= 1.63
 Cython >= 0.25.2
 wheel >= 0.29.0
 ont_fast5_api == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ version = taiyaki.__version__
 install_requires = [
     "h5py >= 2.2.1",
     "numpy >= 1.14.5",
-    #  Biopython 1.76 last version to support Python 3.5
-    "biopython >= 1.63, <=1.76",
+    "biopython >= 1.63",
     "Cython >= 0.25.2",
     "ont_fast5_api >= 1.2.0",
     "matplotlib >= 2.0.0",


### PR DESCRIPTION
Reverts nanoporetech/taiyaki#79
(I made the new branch from release 5.0 rather than 5.1 by mistake)