### PR TITLE
prepare_mapped_reads.py bugfix

### DIFF
--- a/bin/prepare_mapped_reads.py
+++ b/bin/prepare_mapped_reads.py
@@ -134,7 +134,7 @@ def main():
     # results is an iterable of dicts
     # each dict is a set of return values from a single read
     generate_output_from_results(
-        results, args.output, alphabet_info, args.batch_format)
+        results, args.output, alphabet_info, batch_format=args.batch_format)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Simple bugfix. batch_format argument was not being properly passed to generate_output_from_results here resulting in batch_format being forced to True regardless of --batch_format flag. This causes interoperability issues when preparing datasets for bonito training.